### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and restore different sessions or better workspaces and later restore them.
    Manager:
 
    ```lua
-   local session-manager = require("wezterm-session-manager")
+   local session_manager = require("wezterm-session-manager/session-manager")
    ```
 
 3. **Setup Event Bindings:** Edit your 'wezterm.lua' to include the event


### PR DESCRIPTION
Add /session-manager on local configuration due to error on start. 

runtime error: [string "/home/borba/.config/wezterm/wezterm.lua"]:15: module 'wezterm-session-manager' not found:
        no field package.preload['wezterm-session-manager']
        no file '/etc/xdg/wezterm/wezterm-session-manager.lua'
        no file '/etc/xdg/wezterm/wezterm-session-manager/init.lua'
        no file '/run/user/1000/wezterm/plugins/wezterm-session-manager/plugin/
init.lua'
        no file '/etc/xdg/xdg-pop/wezterm/wezterm-session-manager.lua'
        no file '/etc/xdg/xdg-pop/wezterm/wezterm-session-manager/init.lua'
        no file '/home/borba/.config/wezterm/wezterm-session-manager.lua'
        no file '/home/borba/.config/wezterm/wezterm-session-manager/init.lua'
        no file '/home/borba/.wezterm/wezterm-session-manager.lua'
        no file '/home/borba/.wezterm/wezterm-session-manager/init.lua'
        no file '/usr/local/share/lua/5.4/wezterm-session-manager.lua'
        no file '/usr/local/share/lua/5.4/wezterm-session-manager/init.lua'
        no file '/usr/local/lib/lua/5.4/wezterm-session-manager.lua'
        no file '/usr/local/lib/lua/5.4/wezterm-session-manager/init.lua'
        no file './wezterm-session-manager.lua'
        no file './wezterm-session-manager/init.lua'

        can't load C modules in safe mode
stack traceback:
        [C]: in function 'require'
        [string "/home/borba/.config/wezterm/wezterm.lua"]:15: in main chunk