### PR TITLE
Adjust multi-plat support for Linux (Arch) & MacOS

### DIFF
--- a/session-manager.lua
+++ b/session-manager.lua
@@ -1,7 +1,7 @@
 local wezterm = require("wezterm")
 local session_manager = {}
 
-local os = wezterm.target_triple:find("windows") ~= nil
+local os = wezterm.target_triple
 --- Displays a notification in WezTerm.
 -- @param message string: The notification message to be displayed.
 local function display_notification(message)


### PR DESCRIPTION
Fix issue with linux directory containing the computer name, which isn't part of the path and thus leading to the session not being restored properly. Apply the linux logic also for new pages during restore.

**Edit 22.02.2024**
added support for macos as well. Changed to use rust target triple as specified here https://wezfurlong.org/wezterm/config/lua/wezterm/target_triple.html