### PR TITLE
Prevent exception on restore in multiplexer env

### DIFF
--- a/session-manager.lua
+++ b/session-manager.lua
@@ -102,7 +102,13 @@ local function recreate_workspace(window, workspace_data)
   local foreground_process = initial_pane:get_foreground_process_name()
 
   -- Check if the foreground process is a shell
-  if foreground_process:find("sh") or foreground_process:find("cmd.exe") or foreground_process:find("powershell.exe") or foreground_process:find("pwsh.exe") or foreground_process:find("nu") then
+  if foreground_process and (
+        foreground_process:find("sh")
+        or foreground_process:find("cmd.exe")
+        or foreground_process:find("powershell.exe")
+        or foreground_process:find("pwsh.exe")
+        or foreground_process:find("nu")
+    ) then
     -- Safe to close
     initial_pane:send_text("exit\r")
   else


### PR DESCRIPTION
Restore can fail when called in a multiplexer environment.

`pane:get_foreground_process_name()` is documented as returning `nil` when run in the multiplexer of via SSH. This means that the `foreground_process` variable may be `nil` when the conditional that is searching it as if it were a string will instead raise an exception as it cannot call that operation on `nil`.

To resolve the error, this patch checks for a non-nil value at the start of the conditional.

Fixes #16
